### PR TITLE
Handle the .init_array/.finit_array functions in payload instead of TD-Shim

### DIFF
--- a/rust-quote-payload/Cargo.toml
+++ b/rust-quote-payload/Cargo.toml
@@ -24,6 +24,7 @@ tdx-tdcall = { path = "../../rust-td/tdx-tdcall" }
 tdx-logger =  { path = "../../rust-td/tdx-logger" }
 tdx-exception =  { path = "../../rust-td/tdx-exception" }
 rust-td-layout = { path = "../../rust-td/rust-td-layout" }
+elf-loader = { path = "../../rust-td/elf-loader" }
 
 conquer-once = { version = "0.3.2", default-features = false }
 

--- a/rust-tdshim/src/asm/switch_stack.s
+++ b/rust-tdshim/src/asm/switch_stack.s
@@ -7,19 +7,16 @@
 #       entry_point: usize, // rcx
 #       stack_top: usize,   // rdx
 #       P1: usize,          // r8
-#       INIT: usize         // r9
-#       INIT_SIZE: usize     // 0x28(%rsp)
+#       P2: usize           // r9
 #       );
 .global switch_stack_call
 switch_stack_call:
-        movq 0x28(%rsp), %r10
 
         subq $32, %rdx
         movq %rdx, %rsp
         movq %rcx, %rax
         movq %r8, %rcx
         movq %r9, %rdx
-        movq %r10, %r8
         call *%rax
 
         int $3

--- a/rust-tdshim/src/main.rs
+++ b/rust-tdshim/src/main.rs
@@ -15,7 +15,7 @@ mod mp;
 mod tcg;
 
 extern "win64" {
-    fn switch_stack_call(entry_point: usize, stack_top: usize, P1: usize, P2: usize, INIT: usize);
+    fn switch_stack_call(entry_point: usize, stack_top: usize, P1: usize, P2: usize);
 }
 
 mod asm;
@@ -329,7 +329,7 @@ pub extern "win64" fn _start(
         resource_length: 0x80000u64 + 0x20000u64,
     };
 
-    let (entry, basefw, basefwsize, init_start, init_end) = ipl::find_and_report_entry_point(&mut mem, fv_buffer).unwrap();
+    let (entry, basefw, basefwsize) = ipl::find_and_report_entry_point(&mut mem, fv_buffer).unwrap();
     let entry = entry as usize;
 
     const PAYLOAD_NAME_GUID: efi::Guid = efi::Guid::from_fields(
@@ -386,8 +386,7 @@ pub extern "win64" fn _start(
     );
 
     unsafe {
-        let init_size = init_end - init_start;
-        switch_stack_call(entry, stack_top, td_payload_hob_base as usize, init_start as usize, init_size as usize);
+        switch_stack_call(entry, stack_top, td_payload_hob_base as usize, 0);
     }
 
     loop {}

--- a/uefi-pi/src/hob_lib.rs
+++ b/uefi-pi/src/hob_lib.rs
@@ -113,6 +113,26 @@ pub fn get_total_memory_top(hob_list: &[u8]) -> u64 {
     mem_top
 }
 
+pub fn get_fv(hob_list: &[u8]) -> Option<FirmwareVolume> {
+    let mut offset = 0;
+
+    loop {
+        let header: Header = hob_list.pread(offset).unwrap();
+        match header.r#type {
+            HOB_TYPE_FV => {
+                let fv_hob: FirmwareVolume = hob_list.pread(offset).unwrap();
+                return Some(fv_hob);
+            }
+            HOB_TYPE_END_OF_HOB_LIST => {
+                break;
+            }
+            _ => {}
+        }
+        offset += header.length as usize;
+    }
+    None
+}
+
 pub fn get_hob_total_size(hob: &[u8]) -> Option<usize> {
     let phit: HandoffInfoTable = hob.pread(0).ok()?;
     Some(phit.efi_end_of_hob_list as usize - hob.as_ptr() as usize)


### PR DESCRIPTION
Based on the FV base and length passed from TD-Shim to payload